### PR TITLE
Fix skeleton reduction bug and optimise facts removal

### DIFF
--- a/abapc.py
+++ b/abapc.py
@@ -35,7 +35,7 @@ def ABAPC(data,
           base_fact_pct=1.0, set_indep_facts=False, 
           scenario="ABAPC", base_location="results",
           out_mode="opt" , print_models=False,
-          sepsets = None):
+          sepsets = None, smoothing_k=1):
     """
     Args:
     data: np.array
@@ -85,7 +85,7 @@ def ABAPC(data,
         test_PC = [t for t in sepsets[X,Y]]
         for S, p in test_PC:
             dep_type_PC = "indep" if p > alpha else "dep" 
-            I = initial_strength(p, len(S), alpha, 0.5, n_nodes)
+            I = initial_strength(p, len(S), alpha, 0.5, n_nodes, smoothing_k=smoothing_k)
             s_str = 'empty' if len(S)==0 else 's'+'y'.join([str(i) for i in S])
             facts.add((X,S,Y,dep_type_PC, f"{dep_type_PC}({X},{Y},{s_str}).", I))
 
@@ -140,7 +140,7 @@ def ABAPC(data,
                 PC_dep_type = 'indep' if p > alpha else 'dep'
                 s_text = [f"X{r+1}" for r in s]
                 dep_type = 'indep' if nx.algorithms.d_separated(G_est, {f"X{x+1}"}, {f"X{y+1}"}, set(s_text)) else 'dep'
-                I = initial_strength(p, len(s), alpha, 0.5, n_nodes)
+                I = initial_strength(p, len(s), alpha, 0.5, n_nodes, smoothing_k=smoothing_k)
                 if dep_type != PC_dep_type:
                     est_I += -I
                 else:

--- a/utils/graph_utils.py
+++ b/utils/graph_utils.py
@@ -108,8 +108,8 @@ def find_all_d_separations_sets(G, verbose=True, debug=False):
                 depth += 1
     return septests
 
-def initial_strength(p:float, len_S:int, alpha:float, base_strength:float, num_vars:int, verbose=False)->float:
-    w_S = (1-len_S/(num_vars-2))
+def initial_strength(p:float, len_S:int, alpha:float, base_strength:float, num_vars:int, verbose=False, smoothing_k=1)->float:
+    w_S = (1-len_S/(num_vars-2+smoothing_k))  # Add-K smoothing
     # w_S = 1
     if p != None:
         if p < alpha:


### PR DESCRIPTION
## PR Summary: Fix Skeleton Reduction Bug and Optimize Fact Removal

**Commit Hash:** [`6b430593476d8c9559cee5d47c5783ade0554362`](#)

This commit primarily addresses a bug in the `skeleton_reduction` feature, optimizes the logic for removing facts during causal discovery, and introduces a smoothing parameter to improve flexibility, especially when the number of variables is low.

### Key Changes:

1.  **Fixed incomplete path filtering when `skeleton_reduction` is True:**
    *   **Issue:** When `skeleton_reduction` was set to `True`, the logic for excluding paths from the graph did not correctly handle bi-directional independencies in `indep_facts`. It only considered `indep_facts` unidirectionally, leading to some paths that should have been excluded still being considered, potentially affecting the accuracy of the skeleton.
    *   **Fix:** Modified the `compile_and_ground` function in [`causalaba.py`](causalaba.py:70). Now, if `skeleton_rules_reduction` is `True`, all edges defined in `indep_facts` are directly removed from graph `G` (`G.remove_edges_from(indep_facts)`). This ensures that these independence constraints are applied bi-directionally before subsequent path searches.

2.  **Addressed unfaithfulness condition related to `indep_facts` handling:**
    *   **Issue:** A set of incorrect, low-score `indep(X,_)` facts could cause variable `X` to appear disconnected from all other variables when using skeleton reduction. If this led to `len(indep_facts)=0`, the program would not generate any `indep(X,Y,S)` rules. This could prevent the system from correctly counteracting a higher-scoring `dep(X,Y,S)` fact. Consequently, the framework might accept a solution where neither the initial `indep(X,_)` nor the `dep(X,Y,S)` is rejected, resulting in an output graph where `X` is disconnected. This violates the faithfulness condition if a true `dep(X,Y,S)` exists.
    *   **Fix:** The logic for generating `indep` rules in [`causalaba.py`](causalaba.py:104-107) was modified. When `skeleton_rules_reduction` is enabled, an `indep({X},{Y},S)` rule is now generated if `not ap({X},{Y},_,S)` (i.e., no active path exists) if the pair `(X,Y)` (or `(Y,X)`) is explicitly in `dep_facts`. This ensures that `indep` rules are still generated as long as there are relevant `dep` facts to be potentially counteracted. The new test `test_abapc_mock_three_var_collider` in [`tests.py`](tests.py:1190) helps verify this scenario.

3.  **Optimized fact removal logic to avoid unnecessary list traversal:**
    *   **Issue:** In the `CausalABA` function in [`causalaba.py`](causalaba.py:240-273), when a fact needed to be removed, the code would iterate through the current `facts` list to check if other identical "indep" or "dep" facts existed. This was done to decide whether to remove the entry from the `indep_facts` or `dep_facts` sets. This traversal was inefficient, especially with a large number of facts.
    *   **Fix:** Changed the data structure of `indep_facts` and `dep_facts` from `set` to `collections.defaultdict(int)` ([`causalaba.py`](causalaba.py:161-162)). This allows maintaining a counter for each `(X,Y)` fact pair. The counter is incremented when a fact is added and decremented when removed. The entry is only deleted from the dictionary when the counter for that specific fact pair reaches zero. This significantly improves the efficiency of the removal operation.

4.  **Introduced an optional argument `smoothing_k` to adjust the penalty for condition set size:**
    *   **Purpose:** To provide greater flexibility when the number of variables is small and to reduce excessive penalization of the conditioning set size.
    *   **Implementation:**
        *   An optional parameter `smoothing_k` (defaulting to 1) was added to the `ABAPC` function definition in [`abapc.py`](abapc.py:38).
        *   This parameter was also added to the `initial_strength` function in [`utils/graph_utils.py`](utils/graph_utils.py:110) and is used to adjust the weight calculation formula: `w_S = (1-len_S/(num_vars-2+smoothing_k))`. This implements Add-K smoothing, allowing users to control the penalty for the conditioning set size by adjusting `smoothing_k`.
        *   A new test case in [`tests.py`](tests.py:1205) uses `smoothing_k=3` to increase the probability of the `dep` fact in order to trigger unfaithfulness results in the original implementation.

### Affected Files:

*   [`abapc.py`](abapc.py)
*   [`causalaba.py`](causalaba.py)
*   [`tests.py`](tests.py)
*   [`utils/graph_utils.py`](utils/graph_utils.py)
