### PR TITLE
Fix incremental solving by adding `ext_` prefix to atoms in weak constraints and inner strength files

### DIFF
--- a/abapc.py
+++ b/abapc.py
@@ -35,7 +35,7 @@ def ABAPC(data,
           base_fact_pct=1.0, set_indep_facts=False, 
           scenario="ABAPC", base_location="results",
           out_mode="opt" , print_models=False,
-          sepsets = None, smoothing_k=1):
+          sepsets = None, smoothing_k=0):
     """
     Args:
     data: np.array
@@ -98,15 +98,15 @@ def ABAPC(data,
     with open(facts_location_wc, "w") as f:
         for n, s in enumerate(facts):
             if n/len(facts) <= base_fact_pct:
-                f.write(f":~ {s[4]} [-{int(s[5]*1000)}]\n")
+                f.write(f":~ ext_{s[4]} [-{int(s[5]*1000)}]\n")
     ### Save inner strengths
     with open(facts_location_I, "w") as f:
         for n, s in enumerate(facts):
             if n/len(facts) <= base_fact_pct:
-                f.write(f"{s[4]} I={s[5]}, NA\n")
-    
+                f.write(f"ext_{s[4]} I={s[5]}, NA\n")
+
     set_of_model_sets = []
-    model_sets, multiple_solutions = CausalABA(n_nodes, facts_location, weak_constraints=True, skeleton_rules_reduction=True,
+    model_sets, multiple_solutions = CausalABA(n_nodes, facts_location, weak_constraints=True, skeleton_rules_reduction=False,
                                                 fact_pct=base_fact_pct, search_for_models='first',
                                                 opt_mode='optN', print_models=print_models, set_indep_facts=set_indep_facts)
 

--- a/abapc.py
+++ b/abapc.py
@@ -106,7 +106,7 @@ def ABAPC(data,
                 f.write(f"ext_{s[4]} I={s[5]}, NA\n")
 
     set_of_model_sets = []
-    model_sets, multiple_solutions = CausalABA(n_nodes, facts_location, weak_constraints=True, skeleton_rules_reduction=False,
+    model_sets, multiple_solutions = CausalABA(n_nodes, facts_location, weak_constraints=True, skeleton_rules_reduction=True,
                                                 fact_pct=base_fact_pct, search_for_models='first',
                                                 opt_mode='optN', print_models=print_models, set_indep_facts=set_indep_facts)
 

--- a/abapc.py
+++ b/abapc.py
@@ -35,7 +35,7 @@ def ABAPC(data,
           base_fact_pct=1.0, set_indep_facts=False, 
           scenario="ABAPC", base_location="results",
           out_mode="opt" , print_models=False,
-          sepsets = None, smoothing_k=0):
+          sepsets = None, smoothing_k=0, skeleton_rules_reduction=True):
     """
     Args:
     data: np.array
@@ -106,7 +106,7 @@ def ABAPC(data,
                 f.write(f"ext_{s[4]} I={s[5]}, NA\n")
 
     set_of_model_sets = []
-    model_sets, multiple_solutions = CausalABA(n_nodes, facts_location, weak_constraints=True, skeleton_rules_reduction=True,
+    model_sets, multiple_solutions = CausalABA(n_nodes, facts_location, weak_constraints=True, skeleton_rules_reduction=skeleton_rules_reduction,
                                                 fact_pct=base_fact_pct, search_for_models='first',
                                                 opt_mode='optN', print_models=print_models, set_indep_facts=set_indep_facts)
 
@@ -124,7 +124,7 @@ def ABAPC(data,
     if len(models) > 50000:
         logging.info("Pick the first 50,000 models for I calculation")
         models = set(list(models)[:50000]) ## Limit the number of models to 30,000
-    for n, model in tqdm(enumerate(models), desc="Models from ABAPC"):
+    for n, model in tqdm(enumerate(models), desc="Models from ABAPC", total=len(models)):
         ## derive B_est from the model
         B_est = np.zeros((n_nodes, n_nodes))
         for edge in model:

--- a/causalaba.py
+++ b/causalaba.py
@@ -155,7 +155,7 @@ def CausalABA(n_nodes:int, facts_location:str="", print_models:bool=True,
                     statement, Is = line_clean.split(" I=")
                     I,truth = Is.split(",")
                     X, S, Y, dep_type = extract_test_elements_from_symbol(statement)
-                    facts.append((X,S,Y, "ext_"+dep_type, statement, float(I), truth))
+                    facts.append((X,S,Y, dep_type, statement, float(I), truth))
                 else:
                     X, S, Y, dep_type = extract_test_elements_from_symbol(line_clean)
                     facts.append((X,S,Y, dep_type, line_clean, np.nan, "unknown"))
@@ -211,66 +211,64 @@ def CausalABA(n_nodes:int, facts_location:str="", print_models:bool=True,
         logging.info(f"Number of facts removed: {remove_n}")
 
         ## start removing facts if no models are found
-        while n_models == 0:
+        while n_models == 0 and remove_n < len(facts):
             remove_n += 1
             logging.info(f"Number of facts removed: {remove_n}")
 
-            if remove_n < len(facts):
-                reground = False
-                if remove_n > 0:
-                    fact_to_remove = facts[-remove_n]
-                    logging.debug(f"Removing fact {fact_to_remove[4]}")
-                    if fact_to_remove[3] == "ext_indep":
-                        indep_facts[(fact_to_remove[0], fact_to_remove[2])] -= 1
-                        if indep_facts[(fact_to_remove[0], fact_to_remove[2])] == 0:
-                            del indep_facts[(fact_to_remove[0], fact_to_remove[2])]
-                        else:
-                            logging.debug(f"   Not removing fact {fact_to_remove[4]} because there are multiple facts with the same X and Y")                            
-                        # if set_indep_facts:
-                        #     ctl.assign_external(Function(fact_to_remove[3], [Number(fact_to_remove[0]), Number(fact_to_remove[2]), Function(fact_to_remove[4].replace(').','').split(",")[-1])]), True)
-                        # else:
-                        reground = True
-                    else:
-                        dep_facts[(fact_to_remove[0], fact_to_remove[2])] -= 1
-                        if dep_facts[(fact_to_remove[0], fact_to_remove[2])] == 0:
-                            del dep_facts[(fact_to_remove[0], fact_to_remove[2])]
-                        else:
-                            logging.debug(f"   Not removing fact {fact_to_remove[4]} because there are multiple facts with the same X and Y")
-                        ctl.assign_external(Function(fact_to_remove[3], [Number(fact_to_remove[0]), Number(fact_to_remove[2]), Function(fact_to_remove[4].replace(').','').split(",")[-1])]), False)
+            reground = False
+            fact_to_remove = facts[-remove_n]
+            logging.debug(f"Removing fact {fact_to_remove[4]}")
+            if fact_to_remove[3] == "ext_indep":
+                indep_facts[(fact_to_remove[0], fact_to_remove[2])] -= 1
+                if indep_facts[(fact_to_remove[0], fact_to_remove[2])] == 0:
+                    del indep_facts[(fact_to_remove[0], fact_to_remove[2])]
+                else:
+                    logging.debug(f"   Not removing fact {fact_to_remove[4]} because there are multiple facts with the same X and Y")                            
+                # if set_indep_facts:
+                #     ctl.assign_external(Function(fact_to_remove[3], [Number(fact_to_remove[0]), Number(fact_to_remove[2]), Function(fact_to_remove[4].replace(').','').split(",")[-1])]), True)
+                # else:
+                reground = skeleton_rules_reduction
+            else:
+                dep_facts[(fact_to_remove[0], fact_to_remove[2])] -= 1
+                if dep_facts[(fact_to_remove[0], fact_to_remove[2])] == 0:
+                    del dep_facts[(fact_to_remove[0], fact_to_remove[2])]
+                else:
+                    logging.debug(f"   Not removing fact {fact_to_remove[4]} because there are multiple facts with the same X and Y")
+            ctl.assign_external(Function(fact_to_remove[3], [Number(fact_to_remove[0]), Number(fact_to_remove[2]), Function(fact_to_remove[4].replace(').','').split(",")[-1])]), None)
 
-                if reground:
-                    ### Save external statements
-                    with open(facts_location, "w") as f:
-                        for n, s in enumerate(facts[:-remove_n]):
-                            f.write(f"#external ext_{s[4]}\n")
-                    ### Save weak constraints
-                    with open(facts_location_wc, "w") as f:
-                        for n, s in enumerate(facts[:-remove_n]):
-                            f.write(f":~ {s[4]} [-{int(s[5]*1000)}]\n")
-                    ### Save inner strengths
-                    with open(facts_location_I, "w") as f:
-                        for n, s in enumerate(facts[:-remove_n]):
-                            f.write(f"{s[4]} I={s[5]}, NA\n")
-                    logging.info("Recompiling and regrounding...")
-                    ctl = compile_and_ground(n_nodes, facts_location, skeleton_rules_reduction,
-                                    weak_constraints, indep_facts, dep_facts, opt_mode, show)
-                    for fact in facts[:-remove_n]:
-                        ctl.assign_external(Function(fact[3], [Number(fact[0]), Number(fact[2]), Function(fact[4].replace(').','').split(",")[-1])]), True)
-                        logging.debug(f"   True fact: {fact[4]} I={fact[5]}, truth={fact[6]}")
-                    for fact in facts[-remove_n:]:
-                        logging.debug(f"   False fact: {fact[4]} I={fact[5]}, truth={fact[6]}")
-                models = []
-                logging.info("   Solving...")
-                with ctl.solve(yield_=True) as handle:
-                    for model in handle:
-                        models.append(model.symbols(shown=True))
-                        if print_models:
-                            logging.info(f"Answer {len(models)}: {model}")
-                n_models = int(ctl.statistics['summary']['models']['enumerated'])
-                logging.info(f"Number of models: {n_models}")
-                times={key: ctl.statistics['summary']['times'][key] for key in ['total','cpu','solve']}
-                logging.info(f"Times: {times}")
-            
+            if reground:
+                ### Save external statements
+                with open(facts_location, "w") as f:
+                    for n, s in enumerate(facts[:-remove_n]):
+                        f.write(f"#external ext_{s[4]}\n")
+                ### Save weak constraints
+                with open(facts_location_wc, "w") as f:
+                    for n, s in enumerate(facts[:-remove_n]):
+                        f.write(f":~ ext_{s[4]} [-{int(s[5]*1000)}]\n")
+                ### Save inner strengths
+                with open(facts_location_I, "w") as f:
+                    for n, s in enumerate(facts[:-remove_n]):
+                        f.write(f"ext_{s[4]} I={s[5]}, NA\n")
+                logging.info("Recompiling and regrounding...")
+                ctl = compile_and_ground(n_nodes, facts_location, skeleton_rules_reduction,
+                                weak_constraints, indep_facts, dep_facts, opt_mode, show)
+                for fact in facts[:-remove_n]:
+                    ctl.assign_external(Function(fact[3], [Number(fact[0]), Number(fact[2]), Function(fact[4].replace(').','').split(",")[-1])]), True)
+                    logging.debug(f"   True fact: {fact[4]} I={fact[5]}, truth={fact[6]}")
+                for fact in facts[-remove_n:]:
+                    logging.debug(f"   False fact: {fact[4]} I={fact[5]}, truth={fact[6]}")
+            models = []
+            logging.info("   Solving...")
+            with ctl.solve(yield_=True) as handle:
+                for model in handle:
+                    models.append(model.symbols(shown=True))
+                    if print_models:
+                        logging.info(f"Answer {len(models)}: {model}")
+            n_models = int(ctl.statistics['summary']['models']['enumerated'])
+            logging.info(f"Number of models: {n_models}")
+            times={key: ctl.statistics['summary']['times'][key] for key in ['total','cpu','solve']}
+            logging.info(f"Times: {times}")
+        
     elif 'subsets' in search_for_models:
         set_of_models = []
         logging.info(f"Number of subsets to remove: {len(list(powerset(facts)))}")

--- a/causalaba.py
+++ b/causalaba.py
@@ -240,15 +240,15 @@ def CausalABA(n_nodes:int, facts_location:str="", print_models:bool=True,
                 ### Save external statements
                 with open(facts_location, "w") as f:
                     for n, s in enumerate(facts[:-remove_n]):
-                        f.write(f"#external ext_{s[4]}\n")
+                        f.write(f"#external {s[4]}\n")
                 ### Save weak constraints
                 with open(facts_location_wc, "w") as f:
                     for n, s in enumerate(facts[:-remove_n]):
-                        f.write(f":~ ext_{s[4]} [-{int(s[5]*1000)}]\n")
+                        f.write(f":~ {s[4]} [-{int(s[5]*1000)}]\n")
                 ### Save inner strengths
                 with open(facts_location_I, "w") as f:
                     for n, s in enumerate(facts[:-remove_n]):
-                        f.write(f"ext_{s[4]} I={s[5]}, NA\n")
+                        f.write(f"{s[4]} I={s[5]}, NA\n")
                 logging.info("Recompiling and regrounding...")
                 ctl = compile_and_ground(n_nodes, facts_location, skeleton_rules_reduction,
                                 weak_constraints, indep_facts, dep_facts, opt_mode, show)

--- a/tests.py
+++ b/tests.py
@@ -507,11 +507,11 @@ class TestCausalABA(unittest.TestCase):
         ### Save weak constraints
         with open(facts_location_wc, "w") as f:
             for s in facts:
-                f.write(f":~ {s[4]} [-{int(s[5]*1000)}]\n")
+                f.write(f":~ ext_{s[4]} [-{int(s[5]*1000)}]\n")
         ### Save inner strengths
         with open(facts_location_I, "w") as f:
             for s in facts:
-                f.write(f"{s[4]} I={s[5]}, {s[6]}\n")
+                f.write(f"ext_{s[4]} I={s[5]}, {s[6]}\n")
         
         set_of_model_sets = []
         model_sets, multiple_solutions = CausalABA(n_nodes, facts_location, weak_constraints=True, skeleton_rules_reduction=True,
@@ -677,11 +677,11 @@ class TestCausalABA(unittest.TestCase):
         ### Save weak constraints
         with open(facts_location_wc, "w") as f:
             for s in facts:
-                f.write(f":~ {s[4]} [-{int(s[5]*1000)}]\n")
+                f.write(f":~ ext_{s[4]} [-{int(s[5]*1000)}]\n")
         ### Save inner strengths
         with open(facts_location_I, "w") as f:
             for s in facts:
-                f.write(f"{s[4]} I={s[5]}, {s[6]}\n")
+                f.write(f"ext_{s[4]} I={s[5]}, {s[6]}\n")
         
         set_of_model_sets = []
         model_sets, multiple_solutions = CausalABA(n_nodes, facts_location, weak_constraints=True, 
@@ -758,11 +758,11 @@ class TestCausalABA(unittest.TestCase):
         ### Save weak constraints
         with open(facts_location_wc, "w") as f:
             for s in facts:
-                f.write(f":~ {s[4]} [-{int(s[5]*1000)}]\n")
+                f.write(f":~ ext_{s[4]} [-{int(s[5]*1000)}]\n")
         ### Save inner strengths
         with open(facts_location_I, "w") as f:
             for s in facts:
-                f.write(f"{s[4]} I={s[5]}, {s[6]}\n")
+                f.write(f"ext_{s[4]} I={s[5]}, {s[6]}\n")
         
         set_of_model_sets = []
         model_sets, multiple_solutions = CausalABA(n_nodes, facts_location, weak_constraints=True, 
@@ -844,11 +844,11 @@ class TestCausalABA(unittest.TestCase):
         ### Save weak constraints
         with open(facts_location_wc, "w") as f:
             for s in facts:
-                f.write(f":~ {s[4]} [-{int(s[5]*1000)}]\n")
+                f.write(f":~ ext_{s[4]} [-{int(s[5]*1000)}]\n")
         ### Save inner strengths
         with open(facts_location_I, "w") as f:
             for s in facts:
-                f.write(f"{s[4]} I={s[5]}, {s[6]}\n")
+                f.write(f"ext_{s[4]} I={s[5]}, {s[6]}\n")
         
         set_of_model_sets = []
         model_sets, multiple_solutions = CausalABA(n_nodes, facts_location, weak_constraints=True, 
@@ -1135,6 +1135,8 @@ class TestABAPC(unittest.TestCase):
         logging.info(f"Undirected edges from PC: {[(x,y) for (x,y) in cg.find_undirected() if x < y]}")
         logging.info(f"Edges from ABAPC: {est_edges}")
 
+        # This may not pass if smoothing_k is set to other values which changes weak constraints weights distribution
+        # optN mode may pick removed external facts with lower weights but larger sum over facts with higher weights
         models, _ = ABAPC(data=data, alpha=0.05, indep_test='fisherz', scenario=scenario, 
                                 set_indep_facts=False, stable=True, conservative=True, out_mode='optN')
         logging.info(f"Number of models found: {len(models)}")
@@ -1303,13 +1305,13 @@ TestCausalABA().six_node_example()
 TestCausalABA().randomG(7, 1, "ER", 2024)
 TestCausalABA().randomG(8, 1, "ER", 2024)
 TestCausalABA().randomG(9, 1, "ER", 2024) ## 13 seconds, 4 models
-# TestCausalABA().randomG(10, 1, "ER", 2024) ## This test takes 2 minutes to run, 4 models
-# TestCausalABA().randomG(11, 1, "ER", 2024) ## This test takes 45 minutes to run, 48 models
-# TestCausalABA().randomG(12, 1, "ER", 2024) ## This does not finish grounding: RuntimeError: Clasp::Asp::PrgNode value too large
+TestCausalABA().randomG(10, 1, "ER", 2024) ## 4 models
+TestCausalABA().randomG(11, 1, "ER", 2024) ## 48 models
+TestCausalABA().randomG(12, 1, "ER", 2024) ## 12 models
 
-# TestCausalABA().five_node_colombo_PC_facts() ## Does not pass, needs accuracy evaluation
-# TestCausalABA().five_node_sprinkler_PC_facts() ## Does not pass, needs accuracy evaluation
-# TestCausalABA().randomG_PC_facts(4, 1, "ER", 2024) ## Does not pass, needs accuracy evaluation
+TestCausalABA().five_node_colombo_PC_facts()
+TestCausalABA().five_node_sprinkler_PC_facts()
+# TestCausalABA().randomG_PC_facts(4, 1, "ER", 2024)  ## This test takes a little longer
 
 TestMetricsDAG().test_metrics_perfect()
 TestMetricsDAG().test_metrics_errors()

--- a/utils/graph_utils.py
+++ b/utils/graph_utils.py
@@ -108,7 +108,7 @@ def find_all_d_separations_sets(G, verbose=True, debug=False):
                 depth += 1
     return septests
 
-def initial_strength(p:float, len_S:int, alpha:float, base_strength:float, num_vars:int, verbose=False, smoothing_k=1)->float:
+def initial_strength(p:float, len_S:int, alpha:float, base_strength:float, num_vars:int, verbose=False, smoothing_k=0)->float:
     w_S = (1-len_S/(num_vars-2+smoothing_k))  # Add-K smoothing
     # w_S = 1
     if p != None:


### PR DESCRIPTION
This PR fixes incremental solving by changing weak constraints assignment from `indep`/`dep` statements to `ext_indep`/`ext_dep` (removable external facts).

Previous implementation of the weak assignment has two issues:
1. Since weak constraints are not applied on external facts, disabling them will not invalidate the weak constraints. The new implementation makes the weak constraints control more transparent.
2. During each reground, files containing external facts and weak constraints will be rewrite to exclude removed facts. This completely removes weak constraints of remove facts, which could be false negative and provide useful heuristic. 
The new implementation avoids rewriting facts files and assign `None` to remove facts, meaning their truth values are determined by the search process and their weights may still apply to the optimal solution.