### PR TITLE
Optimise rules generation for conflicts resolving

### DIFF
--- a/abapc.py
+++ b/abapc.py
@@ -140,8 +140,8 @@ def ABAPC(data,
             for s,p in I_from_data:
                 PC_dep_type = 'indep' if p > alpha else 'dep'
                 s_text = [f"X{r+1}" for r in s]
-                dep_type = 'indep' if nx.algorithms.d_separated(G_est, {f"X{x+1}"}, {f"X{y+1}"}, set(s_text)) else 'dep'
-                I = initial_strength(p, len(s), alpha, 0.5, n_nodes, smoothing_k=smoothing_k)
+                dep_type = 'indep' if nx.is_d_separator(G_est, {f"X{x+1}"}, {f"X{y+1}"}, set(s_text)) else 'dep'
+                I = initial_strength(p, len(s), alpha, 0.5, n_nodes, smoothing_k=smoothing_k, S_weight=S_weight)
                 if dep_type != PC_dep_type:
                     est_I += -I
                 else:

--- a/abapc.py
+++ b/abapc.py
@@ -35,7 +35,8 @@ def ABAPC(data,
           base_fact_pct=1.0, set_indep_facts=False, 
           scenario="ABAPC", base_location="results",
           out_mode="opt" , print_models=False,
-          sepsets = None, smoothing_k=0, S_weight=True, skeleton_rules_reduction=True):
+          sepsets = None, smoothing_k=0, S_weight=True,
+          skeleton_rules_reduction=True, triple_optimization=False):
     """
     Args:
     data: np.array
@@ -108,7 +109,7 @@ def ABAPC(data,
     set_of_model_sets = []
     model_sets, multiple_solutions = CausalABA(n_nodes, facts_location, weak_constraints=True, skeleton_rules_reduction=skeleton_rules_reduction,
                                                 fact_pct=base_fact_pct, search_for_models='first',
-                                                opt_mode='optN', print_models=print_models, set_indep_facts=set_indep_facts)
+                                                opt_mode='optN', print_models=print_models, set_indep_facts=set_indep_facts, triple_optimization=triple_optimization)
 
     if multiple_solutions:
         for model in model_sets:

--- a/abapc.py
+++ b/abapc.py
@@ -36,7 +36,7 @@ def ABAPC(data,
           scenario="ABAPC", base_location="results",
           out_mode="opt" , print_models=False,
           sepsets = None, smoothing_k=0, S_weight=True,
-          skeleton_rules_reduction=True, triple_optimization=False):
+          skeleton_rules_reduction=True, pre_grounding=False):
     """
     Args:
     data: np.array
@@ -109,7 +109,7 @@ def ABAPC(data,
     set_of_model_sets = []
     model_sets, multiple_solutions = CausalABA(n_nodes, facts_location, weak_constraints=True, skeleton_rules_reduction=skeleton_rules_reduction,
                                                 fact_pct=base_fact_pct, search_for_models='first',
-                                                opt_mode='optN', print_models=print_models, set_indep_facts=set_indep_facts, triple_optimization=triple_optimization)
+                                                opt_mode='optN', print_models=print_models, set_indep_facts=set_indep_facts, pre_grounding=pre_grounding)
 
     if multiple_solutions:
         for model in model_sets:

--- a/causalaba.py
+++ b/causalaba.py
@@ -41,8 +41,9 @@ def compile_and_ground(n_nodes:int, facts_location:str="",
 
     logging.info(f"Compiling the program")
     ### Create Control
-    ctl = Control(['-t %d' % os.cpu_count()])
-    ctl.configuration.solve.parallel_mode = os.cpu_count()
+    cpu_count = min(os.cpu_count() or 1, 64)
+    ctl = Control(['-t %d' % cpu_count])
+    ctl.configuration.solve.parallel_mode = cpu_count
     ctl.configuration.solve.models="0"
     ctl.configuration.solver.seed="2024"
     ctl.configuration.solve.opt_mode = opt_mode

--- a/cd_algorithms/models.py
+++ b/cd_algorithms/models.py
@@ -218,7 +218,7 @@ def run_method(X,
         random_stability(seed)
         start = time.time()
         W_est = ABAPC(data=X, alpha=test_alpha, indep_test=test_name,
-                      scenario=scenario, S_weight=True, triple_optimization=True)
+                      scenario=scenario, S_weight=True, pre_grounding=True)
         elapsed = time.time() - start
         logging.info(f'Time taken for ABAPC: {round(elapsed,2)}s')
 

--- a/cd_algorithms/models.py
+++ b/cd_algorithms/models.py
@@ -217,7 +217,8 @@ def run_method(X,
     elif method == 'abapc':
         random_stability(seed)
         start = time.time()
-        W_est = ABAPC(data=X, alpha=test_alpha, indep_test=test_name, scenario=scenario, S_weight=True)
+        W_est = ABAPC(data=X, alpha=test_alpha, indep_test=test_name,
+                      scenario=scenario, S_weight=True, triple_optimization=True)
         elapsed = time.time() - start
         logging.info(f'Time taken for ABAPC: {round(elapsed,2)}s')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 networkx
+rustworkx
 pandas
 numpy
 scikit-learn

--- a/tests.py
+++ b/tests.py
@@ -1250,6 +1250,37 @@ class TestABAPC(unittest.TestCase):
 
         self.assertEqual(B_est[0], expected)
 
+    def test_pre_grounding(self):
+        from collections import defaultdict
+        scenario = "test_pre_grounding"
+        logger_setup(scenario)
+        ## true DAG
+        B_true = np.array( [[ 0,  0,  1],
+                            [ 0,  0,  1],
+                            [ 0,  0,  0]])
+        n_nodes = B_true.shape[0]
+        n_samples = 5000
+        logging.info(B_true)
+        G_true = nx.DiGraph(pd.DataFrame(B_true, columns=[f"X{i+1}" for i in range(B_true.shape[1])], index=[f"X{i+1}" for i in range(B_true.shape[1])]))
+        logging.info(G_true.edges)
+        truth_DAG_directed_edges = set([(int(e[0].replace("X",""))-1,int(e[1].replace("X",""))-1)for e in G_true.edges])
+        ## generate data
+        data = simulate_discrete_data(n_nodes, n_samples, truth_DAG_directed_edges, 42)
+
+        sepset = defaultdict(list)
+
+        sepset.update({
+            (1, 2): [((0,), 1), ((), 0)],
+            (0, 1): [((), 0.02)],
+        })
+        ## run ABAPC
+        B_est = ABAPC(data=data, alpha=0.01, indep_test='fisherz', scenario=scenario, 
+                      sepsets=sepset, out_mode='optN', set_indep_facts=False, print_models=True,
+                      skeleton_rules_reduction=True, pre_grounding=True)
+
+        expected = {frozenset({(0, 2), (1, 2)}),frozenset({(1, 2)}),frozenset({(2, 1)})}
+
+        self.assertEqual(B_est[0], expected)
 
     def test_abapc_four_node_example(self):
         #### ArgCD paper example ####
@@ -1361,5 +1392,6 @@ TestCausalABA().four_node_example_indeps()
 TestABAPC().test_abapc_mock_three_var()
 TestABAPC().test_abapc_mock_three_var_collider()
 TestABAPC().test_incremental_solving()
+TestABAPC().test_pre_grounding()
 
 logging.info(f"Total time={str(datetime.now()-start)}")

--- a/tests.py
+++ b/tests.py
@@ -1352,7 +1352,7 @@ TestABAPC().test_abapc()
 TestABAPC().test_abapc_indeps()
 TestABAPC().test_abapc_bnlearn()
 
-## Paper Examples
+# Paper Examples
 TestCausalABA().four_node_PC_facts() 
 TestABAPC().test_abapc_four_node_example()
 TestCausalABA().four_node_example_arbitrary()

--- a/utils/graph_utils.py
+++ b/utils/graph_utils.py
@@ -67,6 +67,7 @@ def extract_test_elements_from_symbol(symbol:str)->tuple:
     
     if "dep" in dep_type:
         X, Y, condset = elements.split(",")
+        X, Y = sorted([int(X), int(Y)])
         if condset == "empty":
             S = set()
         elif condset[0] == "s":
@@ -74,10 +75,11 @@ def extract_test_elements_from_symbol(symbol:str)->tuple:
         else:
             raise ValueError(f"Unknown element {condset}")
 
-        return int(X), S, int(Y), dep_type
+        return X, S, Y, dep_type
     elif dep_type in ["arrow", "edge"]:
         X, Y = elements.split(",")
-        return int(X), int(Y), dep_type
+        X, Y = sorted([int(X), int(Y)])
+        return X, Y, dep_type
     else:
         raise ValueError(f"Unknown element {dep_type}")
 


### PR DESCRIPTION
This PR optimises the performance of the framework on real datasets with the following changes:

- **Path Generation**: Replaced `networkx.all_simple_paths` with [`rustworkx.all_simple_paths`](causalaba.py:88), which is approximately 10x faster for simple path generation.
- **Rule Generation**: Path generation is now restricted to variable pairs `(X, Y)` and condition sets `(S)` that appear in external facts. This avoids the expensive process of generating rules for all possible node pairs and the full power set, significantly reducing overhead.
- **Pre-grounding**: Added a [`pre_grounding`](causalaba.py:39) flag to pre-ground atoms. This speeds up the solving step for datasets with a limited number of external facts. A 30-second reduction was observed in the Asia example (5000 samples, fisherz test, S_weight=True).

These changes are based on two observations:
1. Only node pairs and condition sets `(X, Y, S)` that appear in external facts participate in conflict generation.
2. The number of external facts from CI tests grows much slower than the number of all possible node pairs and condition sets.

For example, when running `experiments_bnlearn.py` on the `Sachs` dataset (11 nodes), the number of generated condition sets is reduced from $2^{11}$ (2,048) to 155. For the `Child` dataset (20 nodes), the reduction is from $2^{20}$ (1,048,576) to 378.

Other changes:
- CPU core usage is now limited to 64 to avoid issues with `clingo`'s parallel mode.
- A new test was added for the pre-grounding feature: [`test_pre_grounding`](tests.py:1257).
- When extracting external facts, ignore lines starting with `%` (comments) and sorts `(X, Y)` pairs to ensure consistent ordering.
- Fix the soundness of removed facts which are assigned `None`, by adding external premises, they wouldn't derive their counter parts unless assigned `True` by the solver.